### PR TITLE
修复微信支付参数生成的bug，增加WxAppPrepayOrderInfoMo.cs

### DIFF
--- a/Pay/OSS.PaySdk.Ali/Pay/ZPayTradeApi.cs
+++ b/Pay/OSS.PaySdk.Ali/Pay/ZPayTradeApi.cs
@@ -57,10 +57,10 @@ namespace OSS.PaySdk.Ali.Pay
         #endregion
 
 
-        #region 发起客户端收款（自动唤起
+        #region 发起客户端收款（自动唤起 )
 
         /// <summary>
-        /// 获取客户端App唤起支付请求内容
+        /// 获取客户端App唤起支付请求内容，把这个字符串返回给App端，App就可以调用app sdk中的api调起支付了。
         /// </summary>
         /// <param name="req"></param>
         public ResultMo<string> GetAppTradeContent(ZAddAppTradeReq req)

--- a/Pay/OSS.PaySdk.WX/Pay/Mos/WxAppPrepayOrderInfoMo.cs
+++ b/Pay/OSS.PaySdk.WX/Pay/Mos/WxAppPrepayOrderInfoMo.cs
@@ -1,0 +1,56 @@
+using System;
+using System.Collections.Generic;
+using OSS.Common.Extention;
+
+namespace OSS.PaySdk.Wx.Pay.Mos
+{
+    /// <summary>
+    /// 返回给App端的，直接可用的预付单数据
+    /// </summary>
+    public class WxAppPrepayOrderInfoMo
+    {
+        /// <summary>
+        /// 使用统一下单接口的返回值，创建一个App立即可用的 <see cref="WxAppPrepayOrderInfoMo"/> 类的示例
+        /// </summary>
+        /// <param name="t"></param>
+        /// <param name="wxapi"></param>
+        public WxAppPrepayOrderInfoMo(WxAddPayUniOrderResp t, WxPayTradeApi wxapi)
+        {
+            appid = t.appid;
+            partnerid = t.mch_id;
+            prepayid = t.prepay_id;
+            noncestr = t.nonce_str;
+            timestamp = DateTime.Now.ToUtcSeconds().ToString();
+            var dic = new SortedDictionary<string, object>()
+                {
+                    {"appid",appid},
+                    {"partnerid",partnerid},
+                    {"prepayid",prepayid},
+                    {"noncestr",noncestr},
+                    {"package",package},
+                    {"timestamp",timestamp},
+                };
+            sign = wxapi.GetSign(dic);
+        }
+
+        public string appid { get; private set; }
+        /// <summary>
+        /// 也就是mchid
+        /// </summary>
+        public string partnerid { get; private set; }
+        /// <summary>
+        /// 
+        /// </summary>
+        public string prepayid { get; private set; }
+        public string noncestr { get; private set; }
+        public string timestamp { get; private set; } = DateTime.Now.ToUtcSeconds().ToString();
+
+        /// <summary>
+        /// 常量 "Sign=WXPay"
+        /// </summary>
+        public string package { get; private set; } = "Sign=WXPay";
+
+        public string sign { get; private set; }
+
+    }
+}

--- a/Pay/OSS.PaySdk.WX/Pay/Mos/WxPayAddOrderMos.cs
+++ b/Pay/OSS.PaySdk.WX/Pay/Mos/WxPayAddOrderMos.cs
@@ -273,10 +273,11 @@ namespace OSS.PaySdk.Wx.Pay.Mos
                     {
                         detailStr.Append("{");
                         detailStr.Append("\"goods_id\":\"").Append(item.goods_id).Append("\"");
-                        detailStr.Append(",\"wxpay_goods_id\":\"").Append(item.wxpay_goods_id).Append("\"");
+                        if(!string.IsNullOrEmpty(item.wxpay_goods_id))
+                            detailStr.Append(",\"wxpay_goods_id\":\"").Append(item.wxpay_goods_id).Append("\"");
                         detailStr.Append(",\"goods_name\":\"").Append(item.goods_name).Append("\"");
                         detailStr.Append(",\"quantity\":").Append(item.quantity);
-                        detailStr.Append(",\"price\":").Append(item.wxpay_goods_id);
+                        detailStr.Append(",\"price\":").Append(item.price);
                         detailStr.Append("}");
                     }
                     detailStr.Append("]");

--- a/Pay/OSS.PaySdk.WX/WxPayBaseApi.cs
+++ b/Pay/OSS.PaySdk.WX/WxPayBaseApi.cs
@@ -184,7 +184,36 @@ namespace OSS.PaySdk.Wx
         ///  补充完善 字典sign签名
         /// </summary>
         /// <param name="xmlDirs"></param>
-        protected internal void CompleteDicSign(SortedDictionary<string, object> xmlDirs)
+        public void CompleteDicSign(SortedDictionary<string, object> xmlDirs)
+        {
+            xmlDirs.Add("sign", GetSign(xmlDirs));
+        }
+
+        /// <summary>
+        /// 生成签名,统一方法
+        /// </summary>
+        /// <param name="encryptStr">不含key的参与签名串</param>
+        /// <returns></returns>
+        public string GetSign(string encryptStr)
+        {
+            return Md5.EncryptHexString(string.Concat(encryptStr, "&key=", ApiConfig.Key)).ToUpper();
+        }
+
+        /// <summary>
+        /// 获取时间戳，Unixtimestamp秒数
+        /// </summary>
+        /// <returns></returns>
+        public long GetTimeStamp()
+        {
+            return DateTime.Now.ToUtcSeconds();
+        }
+
+        /// <summary>
+        /// 生成签名,统一方法
+        /// </summary>
+        /// <param name="xmlDirs"></param>
+        /// <returns></returns>
+        public string GetSign(SortedDictionary<string, object> xmlDirs)
         {
             var encStr = string.Join("&",
                 xmlDirs.Select(
@@ -195,10 +224,10 @@ namespace OSS.PaySdk.Wx
                             ? string.Empty
                             : string.Concat(k.Key, "=", str);
                     }));
-            var sign = GetSign(encStr);// Md5.EncryptHexString(string.Concat(encStr, "&key=", ApiConfig.Key)).ToUpper();
-            xmlDirs.Add("sign", sign);
+            var sign = GetSign(encStr);
+            return sign;
         }
-
+        
         /// <summary>
         /// 生成签名,统一方法
         /// </summary>


### PR DESCRIPTION
1.price 参数格式化错误，填成了 wx_goods_id,导致最终的json格式错误。调用报错。
2.新增WxAppPrepayOrderInfoMo.cs，该类直接返回给客户端，就可以调用demo中的代码，调起微信支付了。